### PR TITLE
This is the extra logging code, as of now

### DIFF
--- a/config_override.php
+++ b/config_override.php
@@ -2,3 +2,5 @@
 /***CONFIGURATOR***/
 $sugar_config['js_lang_version'] = 6;
 /***CONFIGURATOR***/
+
+$sugar_config['logger']['channels']['inbound_email_importer']['level'] = 'error';

--- a/modules/Mailer/ImapMailer.php
+++ b/modules/Mailer/ImapMailer.php
@@ -641,4 +641,16 @@ class ImapMailer implements Inbound
 
         return $knownFlags[$flag];
     }
+    /**
+     * --- This is custom support method. NOT STOCK
+     * -- Needed because getStorage method is private
+     * Gets raw content for message as a string
+     * @param int $uid
+     * @return array|string
+     */
+    public function getRawContent(int $uid)
+    {
+        $storage = $this->getStorage();
+        return $storage->getRawContent($uid);
+    }
 }


### PR DESCRIPTION
Wondering if :

* Is this safe (if we add it to a customer instance, will it potentially break the instance or break the scheduler job?
* is output to logger close enough to true raw email (things like line endings, non-utf-8 encoded characters, etc.)?
* Logger itself: is it unnecessarily convoluted? 
** I could not find a good example in stock of BackwardCompatibleLogger and something equivalent to old SugarLogger wouldLog behavior. If my custom code is the only way (or easiest/best way) to get that wouldLog functionality, is my _support_kludgeWouldLog function more-or-less the right way to go about it?
** Even though I'm using PSR-3 to leverage a dedicated logger channel, I ended up doing the actual logging via _ppl, as the formatter for the psr-3 logger is that File formatter, which escapes newlines. Not sure if it is worth it to create entire Handler just to get around that (or if that's the only way to get around it). It would be nice to actually log to the channel, since then I could also configure channel to log to a dedicated log file (lowering the impact of the extra logging and lowering the chances of instance users dealing with the email output if they are on the Log Viewer).

The ideal goal is to have something where Sugar Support (ASEs, most likely) can fork the files and add the additional code but have that code be as external as possible to the stock (forked) code so that it can easily be turned off and so that the call to the logging function can be as little as necessary (one line) within the stock code itself. And, with the raw email content, have something that can be reliably copy/pasted into a .eml file to do further testing outside of the production instance (and to provide in defects to make reproducing defect easier/more-reliable for engineering and QA team).